### PR TITLE
Counts variable not defined on the server if package used as a dependency to another package

### DIFF
--- a/publish-counts.js
+++ b/publish-counts.js
@@ -1,5 +1,5 @@
+Counts = {};
 if (Meteor.isServer) {
-  Counts = {};
   Counts.publish = function(self, name, cursor, options) {
     var count = 0;
     var initializing = true;


### PR DESCRIPTION
For some reason, if the Counts variable is declared within Meteor.isClient or Meteor.isServer, it is not available on the server (triggers a "variable undefined" error when called in a publication).
