### PR TITLE
return 0 if published count doesn't exists

### DIFF
--- a/publish-counts.js
+++ b/publish-counts.js
@@ -91,7 +91,7 @@ if (Meteor.isClient) {
 
   Counts.get = function(name) {
     var count = this.findOne(name);
-    return count && count.count;
+    return count && count.count || 0;
   };
 
   if (Package.blaze) {


### PR DESCRIPTION
Not sure if this makes sense to you.
If users aren't allowed to see items from a collection, I don't want them so see the count so I don't publish it. 
I could handle this on the client, but imho this is the better place.
