### PR TITLE
Fix count for countFromFieldLength

### DIFF
--- a/publish-counts.js
+++ b/publish-counts.js
@@ -68,7 +68,7 @@ if (Meteor.isServer) {
             return;
 
           var next = countFn(fields);
-          count += next - prev[id];
+          count += next - (prev[id] || 0);
           prev[id] = next;
         }
 

--- a/publish-counts_tests.js
+++ b/publish-counts_tests.js
@@ -28,6 +28,9 @@ if (Meteor.isServer) {
     Counts.publish(this, 'posts' + testId, Posts.find({ testId: testId }), {
       countFromFieldLength: 'array'
     });
+    Counts.publish(this, 'posts2' + testId, Posts.find({ _id: 'second' + testId }), {
+      countFromFieldLength: 'array'
+    });
   });
 
   // options.nonReactive
@@ -56,6 +59,7 @@ if (Meteor.isServer) {
       Posts.insert({ testId: testId, array: ['a'] });
       // Because we should handle missing fields
       Posts.insert({ testId: testId });
+      Posts.insert({ _id: 'second' + testId });
     },
     setup3: function(testId) {
       Posts.insert({ _id: 'first' + testId, testId: testId, number: 5 });
@@ -66,6 +70,7 @@ if (Meteor.isServer) {
     },
     update2: function(testId) {
       Posts.update({ _id: 'first' + testId}, {$set: {array: []} });
+      Posts.update({ _id: 'second' + testId }, {$push: {array: ['a']} });
     },
     update3: function(testId) {
       Posts.update({ _id: 'first' + testId}, {$set: {number: 3} });
@@ -137,8 +142,10 @@ if (Meteor.isClient) {
     Meteor.call('setup2', test.id, function() {
       Meteor.subscribe('counts2', test.id, function() {
         test.equal(Counts.get('posts' + test.id), 6);
+        test.equal(Counts.get('posts2' + test.id), 0);
         Meteor.call('update2', test.id, function() {
           test.equal(Counts.get('posts' + test.id), 4);
+          test.equal(Counts.get('posts2' + test.id), 1);
           done();
         });
       });

--- a/publish-counts_tests.js
+++ b/publish-counts_tests.js
@@ -65,10 +65,10 @@ if (Meteor.isServer) {
       Posts.insert({ testId: testId });
     },
     update2: function(testId) {
-      Posts.update({_id: 'first' + testId}, {$set: {array: []}});
+      Posts.update({ _id: 'first' + testId}, {$set: {array: []} });
     },
     update3: function(testId) {
-      Posts.update({ _id: 'first' + testId}, {$set: {number: 3}});
+      Posts.update({ _id: 'first' + testId}, {$set: {number: 3} });
     }
   });
 


### PR DESCRIPTION
This fixes count being `NaN` when going from missing field to available
field when using `countFromFieldLength`.

Count `emails` on `Meteor.users` for a user which have no email then add email and the count isn't `1` as expected but `NaN`.

With this fix you get the expected result.