### PR TITLE
set templating to weak dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.on_use(function (api, where) {
   api.versionsFrom("METEOR@0.9.2");
   api.use('blaze', 'client', { weak:true });
-  api.use('templating', 'client');
+  api.use('templating', 'client', {weak:true});
   api.use('mongo', 'client');
   api.add_files('publish-counts.js');
   api.export('Counts');


### PR DESCRIPTION
Hi
I didn't see that templating has ```blaze```as dependency, so actually the previous pull request didn't solve the strong dependency. Now it should do its job. Thanks for taking this into account.