### PR TITLE
Fix #39 - countFromField broken in Meteor 1.1.0.2 during Mongo doc removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,27 @@ Meteor.publish('posts-visits-count', function() {
 });
 ```
 
-
 And calling `Counts.get('posts-visits')` returns `150`
+
+If the counter field is deeply nested, e.g.:
+
+```
+{ content: 'testing', stats: { visits: 100 } },
+{ content: 'a comment', stats: { visits: 50 } }
+```
+
+Then use an accessor function instead like:
+
+```js
+Meteor.publish('posts-visits-count', function() {
+  Counts.publish(this, 'posts-visits',
+    Posts.find({}, { fields: { _id: 1, 'stats.visits': 1 }}),
+    { countFromField: function (doc) { return doc.stats.visits; } }
+  );
+});
+```
+
+Note that when using an accessor function, you must limit the fields fetched if desired, otherwise Counts will fetch entire documents as it updates the count.
 
 ### countFromFieldLength
 
@@ -77,6 +96,26 @@ Meteor.publish('posts-likes-count', function() {
   Counts.publish(this, 'posts-likes', Posts.find(), { countFromFieldLength: 'likes' });
 });
 ```
+
+If the counter field is deeply nested, e.g.:
+
+```
+{ content: 'testing', popularity: { likes: ['6PNw4GQKMA8CLprZf', 'HKv4S7xQ52h6KsXQ7'] } },
+{ content: 'a comment', popularity: { likes: ['PSmYXrxpwg276aPf5'] } }
+```
+
+Then use an accessor function instead like:
+
+```js
+Meteor.publish('posts-likes-count', function() {
+  Counts.publish(this, 'posts-likes',
+    Posts.find({}, { fields: { _id: 1, 'popularity.likes': 1 }}),
+    { countFromFieldLength: function (doc) { return doc.popularity.likes; } }
+  );
+});
+```
+
+Note that when using an accessor function, you must limit the fields fetched if desired, otherwise Counts will fetch entire documents as it updates the count.
 
 ## Template helper
 

--- a/package.js
+++ b/package.js
@@ -25,7 +25,11 @@ Package.on_test(function (api) {
     'tests/count_test.js',
     'tests/count_non_reactive_test.js',
     'tests/count_from_field_shallow_test.js',
+    'tests/count_from_field_fn_shallow_test.js',
+    'tests/count_from_field_fn_deep_test.js',
     'tests/count_from_field_length_shallow_test.js',
+    'tests/count_from_field_length_fn_shallow_test.js',
+    'tests/count_from_field_length_fn_deep_test.js',
     'tests/no_ready_test.js',
     'tests/observe_handles_test.js',
   ]);

--- a/publish-counts.js
+++ b/publish-counts.js
@@ -33,9 +33,6 @@ if (Meteor.isServer) {
     if (countFn && options.nonReactive)
       throw new Error("options.nonReactive is not yet supported with options.countFromFieldLength or options.countFromFieldSum");
 
-    if (countFn)
-      var prev = {};
-
     if ('function' !== typeof extraField) {
       // ensure the cursor doesn't fetch more than it has to
       cursor._cursorDescription.options.fields = {_id: true};
@@ -49,8 +46,7 @@ if (Meteor.isServer) {
         if (countFn) {
 
           try {
-            prev[id] = countFn(doc);
-            count += prev[id];
+            count += countFn(doc);
           } catch (err) {
             if (err instanceof TypeError) {
               return;
@@ -69,7 +65,6 @@ if (Meteor.isServer) {
         if (countFn) {
           try {
             count -= countFn(doc);
-            delete prev[id];
           } catch (err) {
             if (err instanceof TypeError) {
               return;
@@ -88,9 +83,7 @@ if (Meteor.isServer) {
       observers.changed = function(newDoc, oldDoc) {
         if (countFn) {
           try {
-            var next = countFn(newDoc);
-            count += next - prev[id];
-            prev[id] = next;
+            count += countFn(newDoc) - countFn(oldDoc);
           } catch (err) {
             if (err instanceof TypeError) {
               return;

--- a/publish-counts.js
+++ b/publish-counts.js
@@ -45,11 +45,11 @@ if (Meteor.isServer) {
 
     var count = 0;
     var observers = {
-      added: function(id, fields) {
+      added: function(doc) {
         if (countFn) {
 
           try {
-            prev[id] = countFn(fields);
+            prev[id] = countFn(doc);
             count += prev[id];
           } catch (err) {
             if (err instanceof TypeError) {
@@ -65,10 +65,10 @@ if (Meteor.isServer) {
         if (!initializing)
           self.changed('counts', name, {count: count});
       },
-      removed: function(id, fields) {
+      removed: function(doc) {
         if (countFn) {
           try {
-            count -= countFn(fields);
+            count -= countFn(doc);
             delete prev[id];
           } catch (err) {
             if (err instanceof TypeError) {
@@ -85,10 +85,10 @@ if (Meteor.isServer) {
     };
 
     if (countFn) {
-      observers.changed = function(id, fields) {
+      observers.changed = function(newDoc, oldDoc) {
         if (countFn) {
           try {
-            var next = countFn(fields);
+            var next = countFn(newDoc);
             count += next - prev[id];
             prev[id] = next;
           } catch (err) {
@@ -111,7 +111,7 @@ if (Meteor.isServer) {
     }
 
     if (!options.nonReactive)
-      handle = cursor.observeChanges(observers);
+      handle = cursor.observe(observers);
 
     if (countFn)
       self.added('counts', name, {count: count});

--- a/tests/count_from_field_fn_deep_test.js
+++ b/tests/count_from_field_fn_deep_test.js
@@ -1,0 +1,79 @@
+if (Meteor.isServer) {
+  Meteor.publish('count_from_field_fn_deep', function (testId) {
+    Counts.publish(this, 'posts' + testId, Posts.find({testId: testId}),
+        {countFromField: function (doc) { return doc.a.b; }});
+  });
+
+  Meteor.methods({
+    setup_deep_countFromField_fn: function (testId) {
+      H.insert(testId, 0, {a: {b: 2}});
+      H.insert(testId, 1, {a: {b: 3}});
+    },
+    addDoc_deep_countFromField_fn: function (testId) {
+      H.insert(testId, 2, {a: {b: 4}});
+    },
+    updateDoc_deep_countFromField_fn: function (testId) {
+      H.update(testId, 0, {$set: {a: {b: 1}}});
+    },
+    removeDoc_deep_countFromField_fn: function (testId) {
+      H.remove(testId, 0);
+    },
+  });
+}
+
+if (Meteor.isClient) {
+  Tinytest.addAsync("countFromField: (fn deep) upon subscribe with no records, returns zero", function (test, done) {
+    Meteor.subscribe('count_from_field_fn_deep', test.id, function () {
+      test.equal(H.getCount(test.id), 0);
+      done();
+    });
+  });
+
+  Tinytest.addAsync("countFromField: (fn deep) upon subscribe with records, returns sum of count fields", function (test, done) {
+    Meteor.call('setup_deep_countFromField_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_fn_deep', test.id, function () {
+        test.equal(H.getCount(test.id), 5);
+        done();
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromField: (fn deep) after adding a doc, increments sum by new count field", function (test, done) {
+    Meteor.call('setup_deep_countFromField_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_fn_deep', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('addDoc_deep_countFromField_fn', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, +4);
+          done();
+        });
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromField: (fn deep) after updating the count field of a doc, adjusts sum by change in count field", function (test, done) {
+    Meteor.call('setup_deep_countFromField_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_fn_deep', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('updateDoc_deep_countFromField_fn', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, -1);
+          done();
+        });
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromField: (fn deep) after removing a doc, decrements sum by previous count value", function (test, done) {
+    Meteor.call('setup_deep_countFromField_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_fn_deep', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('removeDoc_deep_countFromField_fn', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, -2);
+          done();
+        });
+      });
+    });
+  });
+}

--- a/tests/count_from_field_fn_shallow_test.js
+++ b/tests/count_from_field_fn_shallow_test.js
@@ -1,0 +1,79 @@
+if (Meteor.isServer) {
+  Meteor.publish('count_from_field_fn_shallow', function (testId) {
+    Counts.publish(this, 'posts' + testId, Posts.find({testId: testId}),
+        {countFromField: function (doc) { return doc.number; }});
+  });
+
+  Meteor.methods({
+    setup_shallow_countFromField_fn: function (testId) {
+      H.insert(testId, 0, {number: 2});
+      H.insert(testId, 1, {number: 3});
+    },
+    addDoc_shallow_countFromField_fn: function (testId) {
+      H.insert(testId, 2, {number: 4});
+    },
+    updateDoc_shallow_countFromField_fn: function (testId) {
+      H.update(testId, 0, {$set: {number: 1}});
+    },
+    removeDoc_shallow_countFromField_fn: function (testId) {
+      H.remove(testId, 0);
+    },
+  });
+}
+
+if (Meteor.isClient) {
+  Tinytest.addAsync("countFromField: (fn shallow) upon subscribe with no records, returns zero", function (test, done) {
+    Meteor.subscribe('count_from_field_fn_shallow', test.id, function () {
+      test.equal(H.getCount(test.id), 0);
+      done();
+    });
+  });
+
+  Tinytest.addAsync("countFromField: (fn shallow) upon subscribe with records, returns sum of count fields", function (test, done) {
+    Meteor.call('setup_shallow_countFromField_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_fn_shallow', test.id, function () {
+        test.equal(H.getCount(test.id), 5);
+        done();
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromField: (fn shallow) after adding a doc, increments sum by new count field", function (test, done) {
+    Meteor.call('setup_shallow_countFromField_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_fn_shallow', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('addDoc_shallow_countFromField_fn', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, +4);
+          done();
+        });
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromField: (fn shallow) after updating the count field of a doc, adjusts sum by change in count field", function (test, done) {
+    Meteor.call('setup_shallow_countFromField_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_fn_shallow', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('updateDoc_shallow_countFromField_fn', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, -1);
+          done();
+        });
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromField: (fn shallow) after removing a doc, decrements sum by previous count value", function (test, done) {
+    Meteor.call('setup_shallow_countFromField_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_fn_shallow', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('removeDoc_shallow_countFromField_fn', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, -2);
+          done();
+        });
+      });
+    });
+  });
+}

--- a/tests/count_from_field_length_fn_deep_test.js
+++ b/tests/count_from_field_length_fn_deep_test.js
@@ -1,0 +1,79 @@
+if (Meteor.isServer) {
+  Meteor.publish('count_from_field_length_fn_deep', function (testId) {
+    Counts.publish(this, 'posts' + testId, Posts.find({testId: testId}), {countFromFieldLength: 'array'});
+  });
+
+  Meteor.methods({
+    setup_deep_countFromFieldLength_fn: function (testId) {
+      H.insert(testId, 0, {array: [1, 2, 3]});
+      H.insert(testId, 1, {array: [1, 2, 3, 4]});
+    },
+    addDoc_deep_countFromFieldLength_fn: function (testId) {
+      H.insert(testId, 2, {array: [1, 2]});
+    },
+    updateDoc_deep_countFromFieldLength_fn: function (testId) {
+      // add 2 elements to array of doc 0
+      H.update(testId, 0, {$set: {array: [1, 2, 3, 4, 5]}});
+    },
+    removeDoc_deep_countFromFieldLength_fn: function (testId) {
+      H.remove(testId, 0);
+    },
+  });
+}
+
+if (Meteor.isClient) {
+  Tinytest.addAsync("countFromFieldLength: (fn deep) upon subscribe with no records, returns zero", function (test, done) {
+    Meteor.subscribe('count_from_field_length_fn_deep', test.id, function () {
+      test.equal(H.getCount(test.id), 0);
+      done();
+    });
+  });
+
+  Tinytest.addAsync("countFromFieldLength: (fn deep) upon subscribe with records, returns sum of lengths of array fields", function (test, done) {
+    Meteor.call('setup_deep_countFromFieldLength_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_length_fn_deep', test.id, function () {
+        test.equal(H.getCount(test.id), 7);
+        done();
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromFieldLength: (fn deep) after adding a doc, increments count by new array length", function (test, done) {
+    Meteor.call('setup_deep_countFromFieldLength_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_length_fn_deep', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('addDoc_deep_countFromFieldLength_fn', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, +2);
+          done();
+        });
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromFieldLength: (fn deep) after updating the count field of a doc, adjusts count by change in array length", function (test, done) {
+    Meteor.call('setup_deep_countFromFieldLength_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_length_fn_deep', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('updateDoc_deep_countFromFieldLength_fn', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, +2);
+          done();
+        });
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromFieldLength: (fn deep) after removing a doc, decrements count by array length", function (test, done) {
+    Meteor.call('setup_deep_countFromFieldLength_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_length_fn_deep', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('removeDoc_deep_countFromFieldLength_fn', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, -3);
+          done();
+        });
+      });
+    });
+  });
+}

--- a/tests/count_from_field_length_fn_shallow_test.js
+++ b/tests/count_from_field_length_fn_shallow_test.js
@@ -1,0 +1,80 @@
+if (Meteor.isServer) {
+  Meteor.publish('count_from_field_length_fn_shallow', function (testId) {
+    Counts.publish(this, 'posts' + testId, Posts.find({testId: testId}),
+        {countFromFieldLength: function (doc) { return doc.array; }});
+  });
+
+  Meteor.methods({
+    setup_shallow_countFromFieldLength_fn: function (testId) {
+      H.insert(testId, 0, {array: [1, 2, 3]});
+      H.insert(testId, 1, {array: [1, 2, 3, 4]});
+    },
+    addDoc_shallow_countFromFieldLength_fn: function (testId) {
+      H.insert(testId, 2, {array: [1, 2]});
+    },
+    updateDoc_shallow_countFromFieldLength_fn: function (testId) {
+      // add 2 elements to array of doc 0
+      H.update(testId, 0, {$set: {array: [1, 2, 3, 4, 5]}});
+    },
+    removeDoc_shallow_countFromFieldLength_fn: function (testId) {
+      H.remove(testId, 0);
+    },
+  });
+}
+
+if (Meteor.isClient) {
+  Tinytest.addAsync("countFromFieldLength: (fn shallow) upon subscribe with no records, returns zero", function (test, done) {
+    Meteor.subscribe('count_from_field_length_fn_shallow', test.id, function () {
+      test.equal(H.getCount(test.id), 0);
+      done();
+    });
+  });
+
+  Tinytest.addAsync("countFromFieldLength: (fn shallow) upon subscribe with records, returns sum of lengths of array fields", function (test, done) {
+    Meteor.call('setup_shallow_countFromFieldLength_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_length_fn_shallow', test.id, function () {
+        test.equal(H.getCount(test.id), 7);
+        done();
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromFieldLength: (fn shallow) after adding a doc, increments count by new array length", function (test, done) {
+    Meteor.call('setup_shallow_countFromFieldLength_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_length_fn_shallow', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('addDoc_shallow_countFromFieldLength_fn', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, +2);
+          done();
+        });
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromFieldLength: (fn shallow) after updating the count field of a doc, adjusts count by change in array length", function (test, done) {
+    Meteor.call('setup_shallow_countFromFieldLength_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_length_fn_shallow', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('updateDoc_shallow_countFromFieldLength_fn', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, +2);
+          done();
+        });
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromFieldLength: (fn shallow) after removing a doc, decrements count by array length", function (test, done) {
+    Meteor.call('setup_shallow_countFromFieldLength_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_length_fn_shallow', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('removeDoc_shallow_countFromFieldLength_fn', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, -3);
+          done();
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
Switch from `observeChanges` to `observe` callbacks to fix #39.

This PR goes a bit further and:

1. splits existing tests into separate files, then extends to test empty collections, existing collections, additions, removals, and changes.
2. adds ability to specify deeply-nested fields for countFromField and countFromFieldLength with an accessor function.

The counter cache provided by `prev` is no longer necessary.

I updated the Readme to document the new function arguments for countFromField and countFromFieldLength.

Tested with Meteor 1.1.0.2, all 39 tests pass.

```
$ cd /tmp
$ meteor create app
$ cd app
$ mkdir packages
$ git clone -b fix/issue-39 --single-branch git@github.com:boxofrox/publish-counts.git packages/publish-counts
$ meteor add tmeasday/publish-counts
$ meteor test-packages packages/publish-counts
$ # open localhost:3000 in browser
```

Could not run the `observe` handlers test with the Meteor fork.  The Meteor fork is version (0.7?) and doesn't like the `api.versionsFrom` call of Meteor 0.9.2.  Regardless, I kept this test in the test suite should the Meteor fork be updated.