### PR TITLE
Add fastCount options for large data sets to minimize unwieldy cursors

### DIFF
--- a/publish-counts.js
+++ b/publish-counts.js
@@ -32,6 +32,15 @@ if (Meteor.isServer) {
       cursor._cursorDescription.options.fields[extraField] = true;
 
     var count = 0;
+    
+    if(options.fastCount){
+      if(cursor._cursorDescription.options.limit)
+        throw new Error("There is no reason to use fastCount with limit.  fastCount is to enable large data sets to have fast but potentially inaccurate cursors.");
+
+      count = cursor.count();
+      cursor._cursorDescription.options.skip = count;
+    }
+    
     var observers = {
       added: function(id, fields) {
         if (countFn) {


### PR DESCRIPTION
I'm working with a very large dataset (100k+ documents)

Publishing counts on this collection has given me very poor performance (cursors were never meant to be this large).

I decided it would be much more efficient if an initial count was taken and then the cursor were modified to skip the initial set.  This has lead to a well over 100x speed increase.

If you were to think of this new feature as something that already exists, it's the equivalent of using a meteor method that returned the current count on a collection and then observing subsequent changes to the collection past the initial count.

This change is not without tradeoffs; of course, things removed from your data set included in the initial count call will not be reflected in the total count.  For most big counts it will not be noticeable (most data sets this large are 99% appended to only).

I am also contemplating creating a way for publish-counts to take advantage of the fact that find({}) is o(1) in MonoDB and to just use polling in that case, as it will actually be the most efficient way to publish a count once you hit a certain # of documents and avoid any cursors.  (But that will be a separate PR.)

Thoughts?