### PR TITLE
Fix/pr 40 - rewrite cursor field optimization

### DIFF
--- a/package.js
+++ b/package.js
@@ -30,6 +30,11 @@ Package.on_test(function (api) {
     'tests/count_from_field_length_shallow_test.js',
     'tests/count_from_field_length_fn_shallow_test.js',
     'tests/count_from_field_length_fn_deep_test.js',
+    'tests/field_limit_count_test.js',
+    'tests/field_limit_count_from_field_test.js',
+    'tests/field_limit_count_from_field_fn_test.js',
+    'tests/field_limit_count_from_field_length_test.js',
+    'tests/field_limit_count_from_field_length_fn_test.js',
     'tests/no_ready_test.js',
     'tests/observe_handles_test.js',
   ]);

--- a/tests/field_limit_count_from_field_fn_test.js
+++ b/tests/field_limit_count_from_field_fn_test.js
@@ -1,0 +1,51 @@
+if (Meteor.isServer) {
+  Tinytest.add("fieldLimit: (countFromField fn) upon publish without field limit, warn user that entire documents are fetched", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id });   // no field limit
+    var conmock = { warn: H.detectRegex(/Collection cursor has no field limits and will fetch entire documents.  consider specifying only required fields./) };
+
+    H.withConsole(conmock, function () {
+      Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
+    });
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    // verify the warning was sent to user
+    test.isTrue(conmock.warn.found(), 'user was not warned of missing cursor field limit');
+
+    // verify no restrictions were set.
+    test.isUndefined(fields, 'Count must keep empty cursor fields limits when user uses accessor function');
+  });
+
+  Tinytest.add("fieldLimit: (countFromField fn) upon publish with count field assigned to field limit, keep existing field limit", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id }, { fields: { likes: true }});   // field limit matches countFromField property.
+
+    Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    test.isNotUndefined(fields, 'cursor is missing fields property');
+    test.isNotUndefined(fields.likes, 'cursor is missing field (likes)');
+    // verify only two fields are fetched.
+    test.length(_.keys(fields), 1, 'cursor has more/less fields than specified');
+  });
+
+  // the user should always include the field used in the accessor function in the cursor field limit.
+  // there is no means to automatically include the count field in the cursor field limit and chaos will ensue when
+  // the user fails to handle this.
+  Tinytest.add("fieldLimit: (countFromField fn) upon publish with other fields assigned to field limit, keep existing field limit", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id }, { fields: { name: true, likes: true }});    // field limit must match countFromField property.
+
+    Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    test.isNotUndefined(fields, 'cursor is missing fields property');
+    test.isNotUndefined(fields.likes, 'cursor is missing field (likes)');
+    test.isNotUndefined(fields.name, 'cursor is missing field (name)');
+    // verify only three fields are fetched.
+    test.length(_.keys(fields), 2, 'cursor has more/less fields than specified');
+  });
+}

--- a/tests/field_limit_count_from_field_length_fn_test.js
+++ b/tests/field_limit_count_from_field_length_fn_test.js
@@ -1,0 +1,51 @@
+if (Meteor.isServer) {
+  Tinytest.add("fieldLimit: (countFromFieldLength fn) upon publish without field limit, warn user that entire documents are fetched", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id });   // no field limit
+    var conmock = { warn: H.detectRegex(/Collection cursor has no field limits and will fetch entire documents.  consider specifying only required fields./) };
+
+    H.withConsole(conmock, function () {
+      Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
+    });
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    // verify the warning was sent to user
+    test.isTrue(conmock.warn.found(), 'user was not warned of missing cursor field limit');
+
+    // verify no restrictions were set.
+    test.isUndefined(fields, 'Count must keep empty cursor fields limits when user uses accessor function');
+  });
+
+  Tinytest.add("fieldLimit: (countFromFieldLength fn) upon publish with count field assigned to field limit, keep existing field limit", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id }, { fields: { likes: true }});   // field limit matches countFromField property.
+
+    Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    test.isNotUndefined(fields, 'cursor is missing fields property');
+    test.isNotUndefined(fields.likes, 'cursor is missing field (likes)');
+    // verify only two fields are fetched.
+    test.length(_.keys(fields), 1, 'cursor has more/less fields than specified');
+  });
+
+  // the user should always include the field used in the accessor function in the cursor field limit.
+  // there is no means to automatically include the count field in the cursor field limit and chaos will ensue when
+  // the user fails to handle this.
+  Tinytest.add("fieldLimit: (countFromFieldLength fn) upon publish with other fields assigned to field limit, keep existing field limit", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id }, { fields: { name: true, likes: true }});    // field limit must match countFromField property.
+
+    Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    test.isNotUndefined(fields, 'cursor is missing fields property');
+    test.isNotUndefined(fields.likes, 'cursor is missing field (likes)');
+    test.isNotUndefined(fields.name, 'cursor is missing field (name)');
+    // verify only three fields are fetched.
+    test.length(_.keys(fields), 2, 'cursor has more/less fields than specified');
+  });
+}

--- a/tests/field_limit_count_from_field_length_test.js
+++ b/tests/field_limit_count_from_field_length_test.js
@@ -1,0 +1,54 @@
+if (Meteor.isServer) {
+  Tinytest.add("fieldLimit: (countFromFieldLength) upon publish without field limit, automatically limit cursor fields to _id and count field", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id });   // no field limit
+
+    Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    test.isNotUndefined(fields, 'cursor is missing fields property');
+    test.isNotUndefined(fields._id, 'cursor is missing field (_id)');
+    test.isNotUndefined(fields.likes, 'cursor is missing field (likes)');
+    // verify only two fields are fetched.
+    test.equal(_.keys(fields).length, 2, 'cursor has more/less than two fields');
+  });
+
+  Tinytest.add("fieldLimit: (countFromFieldLength) upon publish with count field assigned to field limit, keep existing field limit plus _id", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id }, { fields: { likes: true }});   // field limit matches countFromField
+
+    Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    test.isNotUndefined(fields, 'cursor is missing fields property');
+    test.isNotUndefined(fields._id, 'cursor is missing field (_id)');
+    test.isNotUndefined(fields.likes, 'cursor is missing field (likes)');
+    // verify only two fields are fetched.
+    test.equal(_.keys(fields).length, 2, 'cursor has more/less fields than specified (plus _id)');
+  });
+
+  // honestly, devs should never have a reason to do this.  the 'name' field in this example is never used, nor can it ever be.
+  Tinytest.add("fieldLimit: (countFromFieldLength) upon publish with other fields assigned to field limit, warn user and keep existing field limit plus _id and count field", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id }, { fields: { name: true }});
+    var conmock = { warn: H.detectRegex(/unused fields detected in cursor fields option/) };
+
+    H.withConsole(conmock, function () {
+      Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
+    });
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    // verify the warning was sent to user
+    test.isTrue(conmock.warn.found(), 'user was not warned of unused fields');
+
+    test.isNotUndefined(fields, 'cursor is missing fields property');
+    test.isNotUndefined(fields._id, 'cursor is missing field (_id)');
+    test.isNotUndefined(fields.likes, 'cursor is missing field (likes)');
+    test.isNotUndefined(fields.name, 'cursor is missing field (name)');
+    // verify only three fields are fetched.
+    test.equal(_.keys(fields).length, 3, 'cursor has more/less fields than specified (plus _id and likes)');
+  });
+}

--- a/tests/field_limit_count_from_field_test.js
+++ b/tests/field_limit_count_from_field_test.js
@@ -1,0 +1,54 @@
+if (Meteor.isServer) {
+  Tinytest.add("fieldLimit: (countFromField) upon publish without field limit, automatically limit cursor fields to _id and count field", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id });   // no field limit
+
+    Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    test.isNotUndefined(fields, 'cursor is missing fields property');
+    test.isNotUndefined(fields._id, 'cursor is missing field (_id)');
+    test.isNotUndefined(fields.likes, 'cursor is missing field (likes)');
+    // verify only two fields are fetched.
+    test.equal(_.keys(fields).length, 2, 'cursor has more/less than two fields');
+  });
+
+  Tinytest.add("fieldLimit: (countFromField) upon publish with count field assigned to field limit, keep existing field limit plus _id", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id }, { fields: { likes: true }});   // field limit matches countFromField
+
+    Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    test.isNotUndefined(fields, 'cursor is missing fields property');
+    test.isNotUndefined(fields._id, 'cursor is missing field (_id)');
+    test.isNotUndefined(fields.likes, 'cursor is missing field (likes)');
+    // verify only two fields are fetched.
+    test.equal(_.keys(fields).length, 2, 'cursor has more/less fields than specified (plus _id)');
+  });
+
+  // honestly, devs should never have a reason to do this.  the 'name' field in this example is never used, nor can it ever be.
+  Tinytest.add("fieldLimit: (countFromField) upon publish with other fields assigned to field limit, warn user and keep existing field limit plus _id and count field", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id }, { fields: { name: true }});
+    var conmock = { warn: H.detectRegex(/unused fields detected in cursor fields option/) };
+
+    H.withConsole(conmock, function () {
+      Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
+    });
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    // verify the warning was sent to user
+    test.isTrue(conmock.warn.found(), 'user was not warned of unused fields');
+
+    test.isNotUndefined(fields, 'cursor is missing fields property');
+    test.isNotUndefined(fields._id, 'cursor is missing field (_id)');
+    test.isNotUndefined(fields.likes, 'cursor is missing field (likes)');
+    test.isNotUndefined(fields.name, 'cursor is missing field (name)');
+    // verify only three fields are fetched.
+    test.equal(_.keys(fields).length, 3, 'cursor has more/less fields than specified (plus _id and likes)');
+  });
+}

--- a/tests/field_limit_count_test.js
+++ b/tests/field_limit_count_test.js
@@ -1,0 +1,35 @@
+if (Meteor.isServer) {
+  Tinytest.add("fieldLimit: (count) upon publish without field limit, automatically limit cursor fields to _id", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id });     // no field limit
+
+    Counts.publish(pub, 'posts' + test.id, cursor);
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    test.isNotUndefined(fields, 'cursor is missing fields property');
+    test.isNotUndefined(fields._id, 'cursor is missing _id field');
+    // verify only one field is fetched.
+    test.equal(_.keys(fields).length, 1, 'cursor has more than one field')
+  });
+
+  Tinytest.add("fieldLimit: (count) upon publish with field limit, warn user and limit cursor fields to _id", function (test) {
+    var pub = new H.PubMock();
+    var cursor = Posts.find({ testId: test.id }, { fields: { name: true }});    // field manually limited to name
+    var conmock = { warn: H.detectRegex(/unused fields removed from cursor fields option/) };
+
+    H.withConsole(conmock, function () {
+      Counts.publish(pub, 'posts' + test.id, cursor);
+    });
+
+    var fields = cursor._cursorDescription.options.fields;
+
+    // verify the warning was sent to user
+    test.isTrue(conmock.warn.found(), 'user was not warned of unused fields');
+
+    test.isNotUndefined(fields, 'cursor is missing fields property');
+    test.isNotUndefined(fields._id, 'cursor is missing field (_id)');
+    // verify only two fields are fetched.
+    test.equal(_.keys(fields).length, 1, 'cursor has more than one field')
+  });
+}


### PR DESCRIPTION
Implement the following strategy with test units.

1. If the user manually provides a fields specifier in their query, we respect that.

  1. Except for basic counts where the fields are unused and inaccessible, instead warn the user and limit to _id.

  2. When countFromField* is a string, warn user of potential unused fields, but respect their settings.

2. If not, and they pass a function in for one of those arguments, we warn them and don't limit the query.

3. In the usual case, where countFromField* is a string or not set at all, we use what we know to limit fields, and everything is happy.