### PR TITLE
test: verify remove-then-add of count field does not corrupt count

### DIFF
--- a/tests/count_from_field_length_fn_shallow_test.js
+++ b/tests/count_from_field_length_fn_shallow_test.js
@@ -19,6 +19,12 @@ if (Meteor.isServer) {
     removeDoc_shallow_countFromFieldLength_fn: function (testId) {
       H.remove(testId, 0);
     },
+    addField_shallow_countFromFieldLength_fn: function (testId) {
+      H.update(testId, 0, {array: [1, 2, 3, 4, 5]});
+    },
+    removeField_shallow_countFromFieldLength_fn: function (testId) {
+      H.update(testId, 0, {});
+    },
   });
 }
 
@@ -73,6 +79,24 @@ if (Meteor.isClient) {
           var delta = H.getCount(test.id) - before;
           test.equal(delta, -3);
           done();
+        });
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromFieldLength: (fn shallow) after 1) removing count field, 2) readding count field, adjust count by gain minus loss", function (test, done) {
+    Meteor.call('setup_shallow_countFromFieldLength_fn', test.id, function () {
+      Meteor.subscribe('count_from_field_length_fn_shallow', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('removeField_shallow_countFromFieldLength_fn', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, -3, 'removing field did not update count');
+
+          Meteor.call('addField_shallow_countFromFieldLength_fn', test.id, function () {
+            var delta = H.getCount(test.id) - before;
+            test.equal(delta, +2, 'adding field did not update count');
+            done();
+          });
         });
       });
     });

--- a/tests/count_from_field_length_shallow_test.js
+++ b/tests/count_from_field_length_shallow_test.js
@@ -18,6 +18,12 @@ if (Meteor.isServer) {
     removeDoc_shallow_countFromFieldLength: function (testId) {
       H.remove(testId, 0);
     },
+    addField_shallow_countFromFieldLength: function (testId) {
+      H.update(testId, 0, {array: [1, 2, 3, 4, 5]});
+    },
+    removeField_shallow_countFromFieldLength: function (testId) {
+      H.update(testId, 0, {});
+    },
   });
 }
 
@@ -72,6 +78,24 @@ if (Meteor.isClient) {
           var delta = H.getCount(test.id) - before;
           test.equal(delta, -3);
           done();
+        });
+      });
+    });
+  });
+
+  Tinytest.addAsync("countFromFieldLength: (shallow) after 1) removing count field, 2) readding count field, adjust count by gain minus loss", function (test, done) {
+    Meteor.call('setup_shallow_countFromFieldLength', test.id, function () {
+      Meteor.subscribe('count_from_field_length_shallow', test.id, function () {
+        var before = H.getCount(test.id);
+        Meteor.call('removeField_shallow_countFromFieldLength', test.id, function () {
+          var delta = H.getCount(test.id) - before;
+          test.equal(delta, -3, 'removing field did not update count');
+
+          Meteor.call('addField_shallow_countFromFieldLength', test.id, function () {
+            var delta = H.getCount(test.id) - before;
+            test.equal(delta, +2, 'adding field did not update count');
+            done();
+          });
         });
       });
     });


### PR DESCRIPTION
Adding test units to validate #30 is fixed by previously merged PRs.

@tmeasday ping for approval.  If you'd like to me to automatically push trivial changes to the test suite without running them by you, let me know.  For other changes, I prefer to operate as a guest and keep you in the loop before merging.