### PR TITLE
add client method Counts.has() so user can verify existence of counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,34 @@ $ meteor add tmeasday:publish-counts
 
 ## API
 
+### Counts.publish [server]
+
+`Counts.publish(subscription, counter-name, cursor, options)`
+
 Simply call `Counts.publish` within a publication, passing in a name and a cursor:
 
+#### Example 1
 ```js
 Meteor.publish('publication', function() {
   Counts.publish(this, 'name-of-counter', Posts.find());
 });
 ```
 
-On the client side, once you've subscribed to `'publication'`, you can call `Counts.get('name-of-counter')` to get the value of the counter, reactively.
-
 The `Counts.publish` function returns the observer handle that's used to maintain the counter. You can call its `stop` method in order to stop the observer from running.
+
+For more info regarding the `options` parameter, see [Options](#options).
+
+### Counts.get [client]
+
+Once you've subscribed to `'publication'` ([Ex 1](#example-1)), you can call `Counts.get('name-of-counter')` to get the value of the counter, reactively.
+
+This function will always return an integer, `0` is returned if the counter is neither published nor subscribed to.
+
+### Counts.has [client]
+
+Returns true if a counter is both published and subscribed to, otherwise returns false.  This function is reactive.
+
+Useful for validating the existence of counters.
 
 ## Options
 

--- a/package.js
+++ b/package.js
@@ -22,6 +22,7 @@ Package.on_test(function (api) {
 
   api.add_files([
     'tests/helper.js',
+    'tests/has_count_test.js',
     'tests/count_test.js',
     'tests/count_non_reactive_test.js',
     'tests/count_from_field_shallow_test.js',

--- a/publish-counts.js
+++ b/publish-counts.js
@@ -173,10 +173,14 @@ if (Meteor.isServer) {
 if (Meteor.isClient) {
   Counts = new Mongo.Collection('counts');
 
-  Counts.get = function(name) {
+  Counts.get = function countsGet (name) {
     var count = this.findOne(name);
     return count && count.count || 0;
   };
+
+  Counts.has = function countsHas (name) {
+    return !!this.findOne(name);
+  }
 
   if (Package.templating) {
     Package.templating.Template.registerHelper('getPublishedCount', function(name) {

--- a/tests/has_count_test.js
+++ b/tests/has_count_test.js
@@ -1,0 +1,26 @@
+if (Meteor.isServer) {
+  Meteor.publish('Counts.has', function (testId) {
+    Counts.publish(this, 'posts' + testId, Posts.find({ testId: testId }));
+  });
+}
+
+if (Meteor.isClient) {
+  var hasCount = function hasCount (testId) {
+    return Counts.has('posts' + testId);
+  }
+
+  Tinytest.add('Counts.has: when count is not published, return false', function (test, done) {
+    test.isFalse(Counts.has('posts'), 'found unexpected count "posts"');
+  });
+
+  Tinytest.add('Counts.has: when count is published but not subscribed, return false', function (test, done) {
+    test.isFalse(hasCount(test.id), 'found unexpected count "posts' + test.id + '"');
+  });
+
+  Tinytest.addAsync('Counts.has: when count is published and subscribed, return true', function (test, done) {
+    Meteor.subscribe('Counts.has', test.id, function () {
+      test.isTrue(hasCount(test.id), 'missing expected count "posts' + test.id + '"');
+      done();
+    });
+  });
+}


### PR DESCRIPTION
Allow users to test whether a count is published before reading the count.

Why a new function?  I subscribe to the school of thought that a return value should have one meaning.  Counts.get() only returns an integer representing number of docs, fields, or lengths counted.  If no count is published, then nothing is counted and zero is a valid result.

Fixes #32
