### PR TITLE
Add options to suppress warnings from publish-counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ Returns true if a counter is both published and subscribed to, otherwise returns
 
 Useful for validating the existence of counters.
 
+### Counts.noWarnings [server]
+
+This function disables all development warnings on the server from publish-counts.
+
+Not recommended for use by development teams, as warnings are meant to inform
+library users of potential conflicts, inefficiencies, etc in their use of
+publish-counts as a sanity check.  Suppressing all warnings precludes this
+sanity check for future changes.  See the [`noWarnings`](#nowarnings) option
+for fine-grained warning suppression.
+
 ## Options
 
 ### Readiness

--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ Meteor.publish('posts-likes-count', function() {
 
 Note that when using an accessor function, you must limit the fields fetched if desired, otherwise Counts will fetch entire documents as it updates the count.
 
+### noWarnings
+
+Pass the option, `noWarnings: true`, to `Counts.publish` to disable its warnings in
+a development environment.
+
+Each call to `Counts.publish` may print warnings to the console to inform
+developers of non-fatal conflicts with publish-counts.  In some situations, a
+developer may intentionally invoke `Counts.publish` in a way that generates a
+warnings.  Use this option to disable warnings for a particular invocation of
+`Counts.publish`.
+
+This fine-grained method of warning suppression is recommended for development
+teams that rely on warnings with respect to future changes.
+
 ## Template helper
 
 To easily show the counter value within your templates, you can use the `getPublishedCount` template helper.

--- a/package.js
+++ b/package.js
@@ -37,6 +37,7 @@ Package.on_test(function (api) {
     'tests/field_limit_count_from_field_length_test.js',
     'tests/field_limit_count_from_field_length_fn_test.js',
     'tests/no_ready_test.js',
+    'tests/no_warn_test.js',
     'tests/observe_handles_test.js',
   ]);
 });

--- a/publish-counts.js
+++ b/publish-counts.js
@@ -1,3 +1,5 @@
+var noWarnings = false;
+
 if (Meteor.isServer) {
   Counts = {};
   Counts.publish = function(self, name, cursor, options) {
@@ -106,6 +108,11 @@ if (Meteor.isServer) {
   // back compatibility
   publishCount = Counts.publish;
 
+  Counts.noWarnings = function (noWarn) {
+    // suppress warnings if no arguments, or first argument is truthy
+    noWarnings = (0 == arguments.length || !!noWarn);
+  }
+
   Counts._safeAccessorFunction = function safeAccessorFunction (fn) {
     // ensure that missing fields don't corrupt the count.  If the count field
     // doesn't exist, then it has a zero count.
@@ -176,7 +183,7 @@ if (Meteor.isServer) {
   }
 
   Counts._warn = function warn (noWarn) {
-    if (noWarn)
+    if (noWarnings || noWarn)
       return;
 
     var args = Array.prototype.slice.call(arguments, 1);

--- a/publish-counts.js
+++ b/publish-counts.js
@@ -183,7 +183,7 @@ if (Meteor.isServer) {
   }
 
   Counts._warn = function warn (noWarn) {
-    if (noWarnings || noWarn)
+    if (noWarnings || noWarn || 'production' == process.env.NODE_ENV)
       return;
 
     var args = Array.prototype.slice.call(arguments, 1);

--- a/publish-counts.js
+++ b/publish-counts.js
@@ -37,7 +37,8 @@ if (Meteor.isServer) {
     if (countFn && options.nonReactive)
       throw new Error("options.nonReactive is not yet supported with options.countFromFieldLength or options.countFromFieldSum");
 
-    cursor._cursorDescription.options.fields = Counts._optimizeQueryFields(cursor._cursorDescription.options.fields, extraField);
+    cursor._cursorDescription.options.fields =
+      Counts._optimizeQueryFields(cursor._cursorDescription.options.fields, extraField, options.noWarnings);
 
     var count = 0;
     var observers = {
@@ -122,13 +123,14 @@ if (Meteor.isServer) {
     };
   }
 
-  Counts._optimizeQueryFields = function optimizeQueryFields (fields, extraField) {
+  Counts._optimizeQueryFields = function optimizeQueryFields (fields, extraField, noWarn) {
     switch (typeof extraField) {
       case 'function':      // accessor function used.
         if (undefined === fields) {
           // user did not place restrictions on cursor fields.
-          console.warn('publish-counts: Collection cursor has no field limits and will fetch entire documents.  ' +
-                      'consider specifying only required fields.');
+          Counts._warn(noWarn,
+                       'publish-counts: Collection cursor has no field limits and will fetch entire documents.  ' +
+                       'consider specifying only required fields.');
           // if cursor field limits are empty to begin with, leave them empty.  it is the
           // user's responsibility to specify field limits when using accessor functions.
         }
@@ -149,14 +151,18 @@ if (Meteor.isServer) {
         fields[extraField] = true;
 
         if (2 < _.keys(fields).length)
-          console.warn('publish-counts: unused fields detected in cursor fields option', _.omit(fields, ['_id', extraField]));
+          Counts._warn(noWarn,
+                       'publish-counts: unused fields detected in cursor fields option',
+                       _.omit(fields, ['_id', extraField]));
 
         // use modified field limits.  automatically defaults to _id and extraField if none specified by user.
         return fields;
 
       case 'undefined':     // basic count
         if (fields && 0 < _.keys(_.omit(fields, ['_id'])).length)
-          console.warn('publish-counts: unused fields removed from cursor fields option.', _.omit(fields, ['_id']));
+          Counts._warn(noWarn,
+                       'publish-counts: unused fields removed from cursor fields option.',
+                       _.omit(fields, ['_id']));
 
         // dispose of user field limits, only _id is required
         fields = { _id:  true };
@@ -167,6 +173,14 @@ if (Meteor.isServer) {
       default:
         throw new Error("unknown invocation of Count.publish() detected.");
     }
+  }
+
+  Counts._warn = function warn (noWarn) {
+    if (noWarn)
+      return;
+
+    var args = Array.prototype.slice.call(arguments, 1);
+    console.warn.apply(console, args);
   }
 }
 

--- a/tests/field_limit_count_from_field_fn_test.js
+++ b/tests/field_limit_count_from_field_fn_test.js
@@ -1,21 +1,54 @@
 if (Meteor.isServer) {
-  Tinytest.add("fieldLimit: (countFromField fn) - upon publish without field limit, warn user that entire documents are fetched", function (test) {
+  Tinytest.add("fieldLimit: (countFromField fn) - upon publish without field limit, always leave field limit undefined", function (test) {
     var pub = new H.PubMock();
     var cursor = Posts.find({ testId: test.id });   // no field limit
-    var conmock = { warn: H.detectRegex(/Collection cursor has no field limits and will fetch entire documents.  consider specifying only required fields./) };
 
-    H.withConsole(conmock, function () {
-      Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
-    });
+    Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
 
     var fields = cursor._cursorDescription.options.fields;
-
-    // verify the warning was sent to user
-    test.isTrue(conmock.warn.found(), 'user was not warned of missing cursor field limit');
 
     // verify no restrictions were set.
     test.isUndefined(fields, 'Count must keep empty cursor fields limits when user uses accessor function');
   });
+
+  { // WARNING TESTS
+
+    //  upon publish
+    //    without field limit
+    //    with warnings
+    //    in development
+    //  warn user
+    Tinytest.add("fieldLimit: (countFromField fn) - upon publish without field limit, " +
+                 "with warnings, in development, warn user that entire documents are fetched", function (test) {
+      var pub = new H.PubMock();
+      var cursor = Posts.find({ testId: test.id });   // no field limit
+      var conmock = { warn: H.detectRegex(/Collection cursor has no field limits and will fetch entire documents.  consider specifying only required fields./) };
+
+      H.withConsole(conmock, function () {
+        Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
+      });
+
+      // verify the warning was sent to user
+      test.isTrue(conmock.warn.found(), 'expected warning');
+    });
+
+    //  upon publish
+    //    without field limit
+    //  warning uses Counts._warn
+    Tinytest.add("fieldLimit: (countFromField fn) - upon publish without field limit, " +
+                 "warn with Counts._warn()", function (test) {
+      var pub    = new H.PubMock();
+      var cursor = Posts.find({ testId: test.id });   // no field limit
+      var flag   = false;
+
+      H.withWarn(function () { flag = true; }, function () {
+        Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
+      });
+
+      test.isTrue(flag, 'did not call Counts._warn()');
+    });
+
+  } // END WARNING TESTS
 
   Tinytest.add("fieldLimit: (countFromField fn) - upon publish with count field assigned to field limit, keep existing field limit", function (test) {
     var pub = new H.PubMock();

--- a/tests/field_limit_count_from_field_length_fn_test.js
+++ b/tests/field_limit_count_from_field_length_fn_test.js
@@ -1,21 +1,55 @@
 if (Meteor.isServer) {
-  Tinytest.add("fieldLimit: (countFromFieldLength fn) - upon publish without field limit, warn user that entire documents are fetched", function (test) {
+  Tinytest.add("fieldLimit: (countFromFieldLength fn) - upon publish without field limit, always leave field limit undefined",
+               function (test) {
     var pub = new H.PubMock();
     var cursor = Posts.find({ testId: test.id });   // no field limit
-    var conmock = { warn: H.detectRegex(/Collection cursor has no field limits and will fetch entire documents.  consider specifying only required fields./) };
 
-    H.withConsole(conmock, function () {
-      Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
-    });
+    Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
 
     var fields = cursor._cursorDescription.options.fields;
-
-    // verify the warning was sent to user
-    test.isTrue(conmock.warn.found(), 'user was not warned of missing cursor field limit');
 
     // verify no restrictions were set.
     test.isUndefined(fields, 'Count must keep empty cursor fields limits when user uses accessor function');
   });
+
+  { // WARNING TESTS
+
+    //  upon publish
+    //    without field limit
+    //    with warnings
+    //    in development
+    //  warn user
+    Tinytest.add("fieldLimit: (countFromFieldLength fn) - upon publish without field limit, " +
+                 "with warnings, in development, warn user that entire documents are fetched", function (test) {
+      var pub = new H.PubMock();
+      var cursor = Posts.find({ testId: test.id });   // no field limit
+      var conmock = { warn: H.detectRegex(/Collection cursor has no field limits and will fetch entire documents.  consider specifying only required fields./) };
+
+      H.withConsole(conmock, function () {
+        Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
+      });
+
+      // verify the warning was sent to user
+      test.isTrue(conmock.warn.found(), 'expected warning');
+    });
+
+    //  upon publish
+    //    without field limit
+    //  warning uses Counts._warn
+    Tinytest.add("fieldLimit: (countFromFieldLength fn) - upon publish without field limit, " +
+                 "warn with Counts._warn()", function (test) {
+      var pub    = new H.PubMock();
+      var cursor = Posts.find({ testId: test.id });   // no field limit
+      var flag   = false;
+
+      H.withWarn(function () { flag = true; }, function () {
+        Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: function (doc) { return doc.likes; } });
+      });
+
+      test.isTrue(flag, 'did not call Counts._warn()');
+    });
+
+  } // END WARNING TESTS
 
   Tinytest.add("fieldLimit: (countFromFieldLength fn) - upon publish with count field assigned to field limit, keep existing field limit", function (test) {
     var pub = new H.PubMock();

--- a/tests/field_limit_count_from_field_length_test.js
+++ b/tests/field_limit_count_from_field_length_test.js
@@ -30,19 +30,14 @@ if (Meteor.isServer) {
   });
 
   // honestly, devs should never have a reason to do this.  the 'name' field in this example is never used, nor can it ever be.
-  Tinytest.add("fieldLimit: (countFromFieldLength) - upon publish with other fields assigned to field limit, warn user and keep existing field limit plus _id and count field", function (test) {
+  Tinytest.add("fieldLimit: (countFromFieldLength) - upon publish with other fields assigned to field limit, " +
+               "always keep existing field limit plus _id and count field", function (test) {
     var pub = new H.PubMock();
     var cursor = Posts.find({ testId: test.id }, { fields: { name: true }});
-    var conmock = { warn: H.detectRegex(/unused fields detected in cursor fields option/) };
 
-    H.withConsole(conmock, function () {
-      Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
-    });
+    Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
 
     var fields = cursor._cursorDescription.options.fields;
-
-    // verify the warning was sent to user
-    test.isTrue(conmock.warn.found(), 'user was not warned of unused fields');
 
     test.isNotUndefined(fields, 'cursor is missing fields property');
     test.isNotUndefined(fields._id, 'cursor is missing field (_id)');
@@ -51,4 +46,45 @@ if (Meteor.isServer) {
     // verify only three fields are fetched.
     test.equal(_.keys(fields).length, 3, 'cursor has more/less fields than specified (plus _id and likes)');
   });
+
+  { // WARNING TESTS
+
+    //  upon publish
+    //    with other fields assigned to field limit
+    //    with warnings
+    //    in development
+    //  warn user
+    Tinytest.add("fieldLimit: (countFromFieldLength) - upon publish with other fields assigned to field limit, " +
+                 "with warnings, in development, warn user about unused fields",
+                 function (test) {
+      var pub = new H.PubMock();
+      var cursor = Posts.find({ testId: test.id }, { fields: { name: true }});
+      var conmock = { warn: H.detectRegex(/unused fields detected in cursor fields option/) };
+
+      H.withConsole(conmock, function () {
+        Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
+      });
+
+      // verify the warning was sent to user
+      test.isTrue(conmock.warn.found(), 'expected warning');
+    });
+
+    //  upon publish
+    //    with other fields assigned to field limit
+    //  warning uses Counts._warn
+    Tinytest.add("fieldLimit: (countFromFieldLength) - upon publish with other fields assigned to field limit, " +
+                 "warn with Counts._warn()",
+                 function (test) {
+      var pub    = new H.PubMock();
+      var cursor = Posts.find({ testId: test.id }, { fields: { name: true }});
+      var flag   = false;
+
+      H.withWarn(function () { flag = true; }, function () {
+        Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
+      });
+
+      test.isTrue(flag, 'did not call Counts._warn()');
+    });
+
+  } // END WARNING TESTS
 }

--- a/tests/field_limit_count_from_field_test.js
+++ b/tests/field_limit_count_from_field_test.js
@@ -30,19 +30,13 @@ if (Meteor.isServer) {
   });
 
   // honestly, devs should never have a reason to do this.  the 'name' field in this example is never used, nor can it ever be.
-  Tinytest.add("fieldLimit: (countFromField) - upon publish with other fields assigned to field limit, warn user and keep existing field limit plus _id and count field", function (test) {
+  Tinytest.add("fieldLimit: (countFromField) - upon publish with other fields assigned to field limit, always keep existing field limit plus _id and count field", function (test) {
     var pub = new H.PubMock();
     var cursor = Posts.find({ testId: test.id }, { fields: { name: true }});
-    var conmock = { warn: H.detectRegex(/unused fields detected in cursor fields option/) };
 
-    H.withConsole(conmock, function () {
-      Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
-    });
+    Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
 
     var fields = cursor._cursorDescription.options.fields;
-
-    // verify the warning was sent to user
-    test.isTrue(conmock.warn.found(), 'user was not warned of unused fields');
 
     test.isNotUndefined(fields, 'cursor is missing fields property');
     test.isNotUndefined(fields._id, 'cursor is missing field (_id)');
@@ -51,4 +45,42 @@ if (Meteor.isServer) {
     // verify only three fields are fetched.
     test.equal(_.keys(fields).length, 3, 'cursor has more/less fields than specified (plus _id and likes)');
   });
+
+  { // WARNING TESTS
+
+    //  upon publish with other fields assigned to field limit
+    //    with warnings
+    //    in development
+    //  warn user
+    Tinytest.add("fieldLimit: (countFromField) - upon publish with other fields assigned to field limit, " +
+                 "with warnings, in development, warn user about unused fields", function (test) {
+      var pub = new H.PubMock();
+      var cursor = Posts.find({ testId: test.id }, { fields: { name: true }});
+      var conmock = { warn: H.detectRegex(/unused fields detected in cursor fields option/) };
+
+      H.withConsole(conmock, function () {
+        Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
+      });
+
+      // verify the warning was sent to user
+      test.isTrue(conmock.warn.found(), 'expected warning');
+    });
+
+    //  upon publish
+    //    with other fields assigned to field limit
+    //  warning uses Counts._warn
+    Tinytest.add("fieldLimit: (countFromField) - upon publish with other fields assigned to field limit, " +
+                 "warn with Counts._warn()", function (test) {
+      var pub    = new H.PubMock();
+      var cursor = Posts.find({ testId: test.id }, { fields: { name: true }});
+      var flag   = false;
+
+      H.withWarn(function () { flag = true; }, function () {
+        Counts.publish(pub, 'posts' + test.id, cursor, { countFromField: 'likes' });
+      });
+
+      test.isTrue(flag, 'did not call Counts._warn()');
+    });
+
+  } // END WARNING TESTS
 }

--- a/tests/field_limit_count_test.js
+++ b/tests/field_limit_count_test.js
@@ -13,23 +13,55 @@ if (Meteor.isServer) {
     test.equal(_.keys(fields).length, 1, 'cursor has more than one field')
   });
 
-  Tinytest.add("fieldLimit: (count) - upon publish with field limit, warn user and limit cursor fields to _id", function (test) {
+  Tinytest.add("fieldLimit: (count) - upon publish with field limit, always limit cursor fields to _id", function (test) {
     var pub = new H.PubMock();
     var cursor = Posts.find({ testId: test.id }, { fields: { name: true }});    // field manually limited to name
-    var conmock = { warn: H.detectRegex(/unused fields removed from cursor fields option/) };
 
-    H.withConsole(conmock, function () {
-      Counts.publish(pub, 'posts' + test.id, cursor);
-    });
+    Counts.publish(pub, 'posts' + test.id, cursor);
 
     var fields = cursor._cursorDescription.options.fields;
-
-    // verify the warning was sent to user
-    test.isTrue(conmock.warn.found(), 'user was not warned of unused fields');
 
     test.isNotUndefined(fields, 'cursor is missing fields property');
     test.isNotUndefined(fields._id, 'cursor is missing field (_id)');
     // verify only two fields are fetched.
-    test.equal(_.keys(fields).length, 1, 'cursor has more than one field')
+    test.equal(_.keys(fields).length, 1, 'cursor has more than one field');
   });
+
+  { // WARNING TESTS
+
+    //  upon publish
+    //    with field limit
+    //    with warnings
+    //    in development
+    //  warn user
+    Tinytest.add("fieldLimit: (count) - upon publish with field limit, with warnings, in development, " +
+                 "warn user unused fields were removed", function (test) {
+      var pub = new H.PubMock();
+      var cursor = Posts.find({ testId: test.id }, { fields: { name: true }});    // field manually limited to name
+      var conmock = { warn: H.detectRegex(/unused fields removed from cursor fields option/) };
+
+      H.withConsole(conmock, function () {
+        Counts.publish(pub, 'posts' + test.id, cursor);
+      });
+
+      // verify the warning was sent to user
+      test.isTrue(conmock.warn.found(), 'expected warning');
+    });
+
+    //  upon publish
+    //    with field limit
+    //  warning uses Counts._warn
+    Tinytest.add("fieldLimit: (count) - upon publish with field limit, warn with Counts._warn()", function (test) {
+      var pub     = new H.PubMock();
+      var cursor  = Posts.find({ testId: test.id }, { fields: { name: true }});    // field manually limited to name
+      var flag    = false;
+
+      H.withWarn(function () { flag = true; }, function () {
+        Counts.publish(pub, 'posts' + test.id, cursor);
+      });
+
+      test.isTrue(flag, 'did not call Counts._warn()');
+    });
+
+  } // END WARNING TESTS
 }

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -92,6 +92,14 @@ if (Meteor.isServer) {
     Posts.update(H.docId(testId, docNum), modifier);
   }
 
+  // helper function to modify node environment variables then restore them after testing.
+  this.H.withNodeEnv = (function withNodeEnv (env, fn) {
+    var backup = process.env;
+    process.env = _.extend({}, backup, env);
+    fn();
+    process.env = backup;
+  }).bind(this);
+
   // helper function to disable then restore the global state for Counts.noWarnings().
   this.H.withNoWarnings = (function withNoWarnings (fn) {
     Counts.noWarnings();

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -92,6 +92,13 @@ if (Meteor.isServer) {
     Posts.update(H.docId(testId, docNum), modifier);
   }
 
+  // helper function to disable then restore the global state for Counts.noWarnings().
+  this.H.withNoWarnings = (function withNoWarnings (fn) {
+    Counts.noWarnings();
+    fn();
+    Counts.noWarnings(false);
+  }).bind(this);
+
   // helper function to modify Counts._warn() then restore it after testing.
   this.H.withWarn = (function withWarn (warn, fn) {
     var backup = Counts._warn;

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -92,6 +92,14 @@ if (Meteor.isServer) {
     Posts.update(H.docId(testId, docNum), modifier);
   }
 
+  // helper function to modify Counts._warn() then restore it after testing.
+  this.H.withWarn = (function withWarn (warn, fn) {
+    var backup = Counts._warn;
+    Counts._warn = warn;
+    fn();
+    Counts._warn = backup;
+  }).bind(this);
+
   function hasModifiers (mongoModifier) {
     return _.keys(mongoModifier).some(function (key) {
       return /^\$/.test(key);

--- a/tests/no_warn_test.js
+++ b/tests/no_warn_test.js
@@ -1,0 +1,27 @@
+if (Meteor.isServer) {
+  Tinytest.add("Counts._warn: - print warnings if noWarnings option is falsey", function (test) {
+    var conmock = { warn: H.detectRegex(/test/) };
+
+    [false, null, undefined, '', 0].forEach(function (falsey) {
+      H.withConsole(conmock, function () {
+        Counts._warn(falsey, 'test');
+      });
+
+      // verify the warning was sent to user
+      test.isTrue(conmock.warn.found(), 'warning did not print when noWarnings option is "' + String(falsey) + '"');
+    });
+  });
+
+  Tinytest.add("Counts._warn: - suppress warnings if noWarnings option is truthy", function (test) {
+    var conmock = { warn: H.detectRegex(/test/) };
+
+    [true, 1, '2', {}].forEach(function (truthy) {
+      H.withConsole(conmock, function () {
+        Counts._warn(truthy, 'test');
+      });
+
+      // verify the warning was suppressed
+      test.isFalse(conmock.warn.found(), 'warning not suppressed when noWarnings option is "' + String(truthy) + '"');
+    });
+  });
+}

--- a/tests/no_warn_test.js
+++ b/tests/no_warn_test.js
@@ -64,4 +64,17 @@ if (Meteor.isServer) {
     // verify the warning was sent to user
     test.isTrue(conmock.warn.found(), 'warning did not print after Count.noWarnings(false)');
   });
+
+  Tinytest.add("Counts._warn: - suppress warnings in production environment", function (test) {
+    var conmock = { warn: H.detectRegex(/test/) };
+
+    H.withConsole(conmock, function () {
+      H.withNodeEnv({ NODE_ENV: 'production' }, function () {
+        Counts._warn(false, 'test');
+      });
+    });
+
+    // verify the warning was suppressed
+    test.isFalse(conmock.warn.found(), 'production environment did not suppress warning');
+  });
 }

--- a/tests/no_warn_test.js
+++ b/tests/no_warn_test.js
@@ -24,4 +24,44 @@ if (Meteor.isServer) {
       test.isFalse(conmock.warn.found(), 'warning not suppressed when noWarnings option is "' + String(truthy) + '"');
     });
   });
+
+  Tinytest.add("Counts._warn: - suppress warnings after Counts.noWarnings() is invoked", function (test) {
+    var conmock = { warn: H.detectRegex(/test/) };
+
+    H.withConsole(conmock, function () {
+      H.withNoWarnings(function () {
+        Counts._warn(false, 'test');
+      });
+    });
+
+    // verify the warning was suppressed
+    test.isFalse(conmock.warn.found(), 'Counts.noWarnings() did not suppress warning');
+  });
+
+  Tinytest.add("Counts._warn: - suppress warnings after Counts.noWarnings(true) is invoked", function (test) {
+    var conmock = { warn: H.detectRegex(/test/) };
+
+    H.withConsole(conmock, function () {
+      Counts.noWarnings(true);
+      Counts._warn(false, 'test');
+    });
+
+    // verify the warning was suppressed
+    test.isFalse(conmock.warn.found(), 'Counts.noWarnings(true) did not suppress warning');
+  });
+
+  // NOTE: Counts.noWarnings(false) cannot override { noWarnings: true }.
+  Tinytest.add("Counts._warn: - print warnings after Counts.noWarnings(false) is invoked", function (test) {
+    var conmock = { warn: H.detectRegex(/test/) };
+
+    H.withConsole(conmock, function () {
+      H.withNoWarnings(function () {
+        Counts.noWarnings(false);
+        Counts._warn(false, 'test');
+      });
+    });
+
+    // verify the warning was sent to user
+    test.isTrue(conmock.warn.found(), 'warning did not print after Count.noWarnings(false)');
+  });
 }


### PR DESCRIPTION
- Automatically suppress warnings in production.  Relies on NODE_ENV environment variable.
- Suppress all warnings with `Counts.noWarnings()`.
- Suppress warnings per call to `Counts.publish()` with `noWarnings` option.
- Update README.
- New unit tests to verify suppression of warnings.

@tmeasday @kristijanhusak API review welcome.

Fixes #57