### PR TITLE
skip field specifier optimization with local collections

### DIFF
--- a/package.js
+++ b/package.js
@@ -18,6 +18,7 @@ Package.on_test(function (api) {
   api.use([
     'tmeasday:publish-counts',
     'tinytest',
+    'mongo',
     'facts']);
 
   api.add_files([

--- a/package.js
+++ b/package.js
@@ -25,6 +25,7 @@ Package.on_test(function (api) {
     'tests/helper.js',
     'tests/has_count_test.js',
     'tests/count_test.js',
+    'tests/count_local_collection_test.js',
     'tests/count_non_reactive_test.js',
     'tests/count_from_field_shallow_test.js',
     'tests/count_from_field_fn_shallow_test.js',

--- a/publish-counts.js
+++ b/publish-counts.js
@@ -39,8 +39,10 @@ if (Meteor.isServer) {
     if (countFn && options.nonReactive)
       throw new Error("options.nonReactive is not yet supported with options.countFromFieldLength or options.countFromFieldSum");
 
-    cursor._cursorDescription.options.fields =
-      Counts._optimizeQueryFields(cursor._cursorDescription.options.fields, extraField, options.noWarnings);
+    if (cursor && cursor._cursorDescription) {
+      cursor._cursorDescription.options.fields =
+        Counts._optimizeQueryFields(cursor._cursorDescription.options.fields, extraField, options.noWarnings);
+    }
 
     var count = 0;
     var observers = {

--- a/tests/count_local_collection_test.js
+++ b/tests/count_local_collection_test.js
@@ -1,0 +1,86 @@
+if (Meteor.isServer) {
+  var Locals = new Mongo.Collection(null);
+  var insert = H.insertFactory(Locals);
+  var remove = H.removeFactory(Locals);
+  var update = H.updateFactory(Locals);
+
+  Meteor.publish('count-locals', function (testId) {
+    Counts.publish(this, 'locals' + testId, Locals.find({ testId: testId }));
+  });
+
+  Meteor.methods({
+    setup_count_locals: function (testId) {
+      insert(testId, 0, { name: "i'm a test local" });
+      insert(testId, 1, { name: "i'm a test local" });
+      insert(testId, 2, { name: "i'm a test local" });
+    },
+    addDoc_count_locals: function (testId) {
+      insert(testId, 3, { name: "i'm a test local" });
+    },
+    updateDoc_count_locals: function (testId) {
+      update(testId, 0, { $set: { name: "i'm an edited local" } });
+    },
+    removeDoc_count_locals: function (testId) {
+      remove(testId, 0);
+    },
+  });
+}
+
+if (Meteor.isClient) {
+  var getCount = H.getCountFactory('locals');   // name must match name used in `Counts.publish` above.
+
+  Tinytest.addAsync("count: (local collection) - upon subscribe with no records, return zero", function (test, done) {
+    Meteor.subscribe('count-locals', test.id, function () {
+      test.equal(getCount(test.id), 0);
+      done();
+    });
+  });
+
+  Tinytest.addAsync("count: (local collection) - upon subscribe with records, return number of records", function (test, done) {
+    Meteor.call('setup_count_locals', test.id, function () {
+      Meteor.subscribe('count-locals', test.id, function () {
+        test.equal(getCount(test.id), 3);
+        done();
+      });
+    });
+  });
+
+  Tinytest.addAsync("count: (local collection) - after adding a doc, increment count", function (test, done) {
+    Meteor.call('setup_count_locals', test.id, function () {
+      Meteor.subscribe('count-locals', test.id, function () {
+        var before = getCount(test.id);
+        Meteor.call('addDoc_count_locals', test.id, function () {
+          var delta = getCount(test.id) - before;
+          test.equal(delta, +1);
+          done();
+        });
+      });
+    });
+  });
+
+  Tinytest.addAsync("count: (local collection) - after updating a doc, count remains the same", function (test, done) {
+    Meteor.call('setup_count_locals', test.id, function () {
+      Meteor.subscribe('count-locals', test.id, function () {
+        var before = getCount(test.id);
+        Meteor.call('updateDoc_count_locals', test.id, function () {
+          var delta = getCount(test.id) - before;
+          test.equal(delta, 0);
+          done();
+        });
+      });
+    });
+  });
+
+  Tinytest.addAsync("count: (local collection) - after removing a doc, decrement count", function (test, done) {
+    Meteor.call('setup_count_locals', test.id, function () {
+      Meteor.subscribe('count-locals', test.id, function () {
+        var before = getCount(test.id);
+        Meteor.call('removeDoc_count_locals', test.id, function () {
+          var delta = getCount(test.id) - before;
+          test.equal(delta, -1);
+          done();
+        });
+      });
+    });
+  });
+}

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -1,4 +1,4 @@
-this.Posts = new Meteor.Collection('posts');
+this.Posts = new Mongo.Collection('posts');
 
 // {this} is provided by IIFE that wraps this file
 // H is for helper


### PR DESCRIPTION
Code reviews welcome.  Will wait a day or two in case @dburles has any input regarding #61 .

To test local collections, I only duplicated the basic count test suite.  I didn't feel there was sufficient difference between the operation of basic count, countFromField, and countFromFieldLength to warrant duplicating the test suites for the latter two.  If anyone prefers I add the extra tests, let me know.

I intend to publish this fix in release/0.7.1, if acceptable.

Fixes #61