### PR TITLE
Update README: include meteor-publish-join

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,8 @@ making such a package, let us know and we'll link it here.
 
 #### Scalable Count Packages
 
-* [publish-performant-counts](https://atmospherejs.com/natestrauser/publish-performant-counts) -
-  Performant solution derived directly from
-  [bullet-counter](https://github.com/bulletproof-meteor/bullet-counter/tree/solution).
+* [publish-performant-counts](https://atmospherejs.com/natestrauser/publish-performant-counts) - Performant solution derived directly from [bullet-counter](https://github.com/bulletproof-meteor/bullet-counter/tree/solution).
+* [meteor-publish-join](https://www.npmjs.com/package/meteor-publish-join) - Publish expensive-aggregated values
 
 #### Compatibility with Meteor < 1.3
 


### PR DESCRIPTION
I made a package named [meteor-publish-join](https://www.npmjs.com/package/meteor-publish-join) aiming to help publish values which are obtained by some kinds of expensive aggregation task: Mongo aggregation, aggregate results from REST calls, etc...

Though [meteor-publish-join](https://www.npmjs.com/package/meteor-publish-join) could do more than publishing count, it could solve the problem [publish-count haves when publishing count of a big dataset](https://github.com/percolatestudio/publish-counts/issues/86). Therefore I include [meteor-publish-join](https://www.npmjs.com/package/meteor-publish-join) in README as the authors suggest.